### PR TITLE
Nodenv

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+Dockerfile
+README.md
+*.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# IDE
+*.code-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,17 @@ FROM conchoid/docker-nodenv-builtins
 LABEL maintainer="digitalpulp"
 
 COPY entrypoint.sh /usr/local/bin/
+
 RUN apk add --no-cache make gcc g++ python git && chmod ugo=rx /usr/local/bin/entrypoint.sh
+
+RUN git clone https://github.com/nodenv/node-build-update-defs.git "$(nodenv root)"/plugins/node-build-update-defs && nodenv update-version-defs
 
 ENTRYPOINT ["entrypoint.sh"]
 
 RUN addgroup -g 82 -S www-data \
   && adduser -u 82 -D -S -G www-data www-data
 
-RUN mkdir /var/www && chown -R www-data:www-data /var/www
+RUN mkdir /var/www && chown -R www-data:www-data /var/www && chown -R www-data:www-data /opt/nodenv
 
 VOLUME /var/www
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM digitalpulp/front-end:codeship-10
+FROM conchoid/docker-nodenv-builtins
 LABEL maintainer="digitalpulp"
+
+COPY entrypoint.sh /usr/local/bin/
+RUN apk add --no-cache make gcc g++ python git && chmod ugo=rx /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["entrypoint.sh"]
 

--- a/Dockerfile-codeship
+++ b/Dockerfile-codeship
@@ -1,5 +1,0 @@
-FROM mhart/alpine-node:8
-LABEL maintainer="digitalpulp"
-
-COPY entrypoint.sh /usr/local/bin/
-RUN apk add --no-cache make gcc g++ python git && chmod ugo=rx /usr/local/bin/entrypoint.sh

--- a/Dockerfile-codeship-10
+++ b/Dockerfile-codeship-10
@@ -1,5 +1,0 @@
-FROM mhart/alpine-node:10
-LABEL maintainer="digitalpulp"
-
-COPY entrypoint.sh /usr/local/bin/
-RUN apk add --no-cache make gcc g++ python git && chmod ugo=rx /usr/local/bin/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Overview
-This container provides node and npm. If a Drupal theme set via environment variables and a package.json is present then npm install is run by the entrypoint script.
-
-Current node version included is 10.15.0
+This container provides nodenv, which provides shims for different versions of node and npm. If a Drupal theme set via environment variables and a .node-version file is present then nodenv install is executed from the theme folder to ensure the specified version of node exists in the image.
 
 # Example docker-compose settings
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,14 +4,16 @@ set -e
 
 WORKING_DIR=${THEME_PATH:-"/var/www/docroot/themes/custom"}
 
-[ "${THEME_NAME}" = "" ] && echo "Error, THEME_NAME variable not specified" && exit 1
+[ "${THEME_NAME}" = "" ] && echo "Error, THEME_NAME variable not specified. Exiting front-end." && exit 1
 
-THEME_DIR = "${WORKING_DIR}/${THEME_NAME}"
+THEME_DIR="${WORKING_DIR}/${THEME_NAME}"
 
 [ ! -d "$THEME_DIR" ] && mkdir -p "$THEME_DIR"
 
 # Execute node-build "nodenv install" command from the theme directory.
-cd ${THEME_DIR} && nodenv install
+# Pass the "-s" flag to skip installing versions that already exist in 
+# the base image.
+cd ${THEME_DIR} && nodenv install -s || true
 
 # Keep the container present if not in a CI, otherwise exit.
 if [ -z ${CI_BUILD_ID} ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,31 +1,18 @@
 #! /bin/sh
 
+set -e
+
 WORKING_DIR=${THEME_PATH:-"/var/www/docroot/themes/custom"}
-# If theme name is set, make sure we are in that directory.
-if [ -n ${THEME_NAME} ]; then
-  cd ${WORKING_DIR}/${THEME_NAME}
-fi
-# If theme name is set and a package-lock.json is present and not in CI,
-# build the node modules.
-if [ -n ${THEME_NAME} -a -r ${WORKING_DIR}/${THEME_NAME}/package-lock.json -a -z ${CI_BUILD_ID} ]; then
-    touch BUILDING.txt
-    npm install --no-save
-elif [ -n ${THEME_NAME} -a -r ${WORKING_DIR}/${THEME_NAME}/package-lock.json -a -n ${CI_BUILD_ID} ]; then
-    # in CI - install node modules with ci command.
-    touch BUILDING.txt
-    npm ci
-fi
-# compile the theme.
-if [ -n ${THEME_NAME} -a -r ${WORKING_DIR}/${THEME_NAME}/gulpfile.js ]; then
-    touch COMPILING.txt
-    node_modules/.bin/gulp build
-    touch INITIALIZED.txt
-elif [ -n ${THEME_NAME} -a -r ${WORKING_DIR}/${THEME_NAME}/Gruntfile.js ]; then
-    touch COMPILING.txt
-    export GRUNT_TARGET=dist
-    node_modules/.bin/grunt build
-    touch INITIALIZED.txt
-fi
+
+[ "${THEME_NAME}" = "" ] && echo "Error, THEME_NAME variable not specified" && exit 1
+
+THEME_DIR = "${WORKING_DIR}/${THEME_NAME}"
+
+[ ! -d "$THEME_DIR" ] && mkdir -p "$THEME_DIR"
+
+# Execute node-build "nodenv install" command from the theme directory.
+cd ${THEME_DIR} && nodenv install
+
 # Keep the container present if not in a CI, otherwise exit.
 if [ -z ${CI_BUILD_ID} ]; then
   tail -f /dev/null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ WORKING_DIR=${THEME_PATH:-"/var/www/docroot/themes/custom"}
 
 THEME_DIR="${WORKING_DIR}/${THEME_NAME}"
 
-[ ! -d "$THEME_DIR" ] && mkdir -p "$THEME_DIR"
+[ ! -f "$THEME_DIR/.node-version" ] && echo "Error, .node-version file not present in theme directory ${THEME_DIR}. Exiting front-end." && exit 1
 
 # Execute node-build "nodenv install" command from the theme directory.
 # Pass the "-s" flag to skip installing versions that already exist in 


### PR DESCRIPTION
Fixes #2
Fixes #1 

Tested this against an active Ballast project by executing `docker build --tag front-end:nodenv .` in the root of this repo, then replacing the front-end docker image reference in the Ballast project's docker-compose-template with `image: front-end:nodenv`.

It works well - try `ahoy compile` in the Ballast project - but has a bit more verbose output for this command, as the node version/s downloaded by the node-build nodenv plugin are for the correct architecture but as Alpine uses `musl` instead of `glibc` node complains (info message) this way:

`node: /usr/lib/libstdc++.so.6: no version information available (required by node)
`

The Ballast project I used has a `.node-version` file in the theme folder (required by this new `front-end` docker image) with the contents `10.16.0`. This `.node-version` file is required by this branch of the `front-end` image, otherwise the entrypoint.sh will fail (as I believe is appropriate) with an error message asking for this version file to be present.

The contents of the file should be set to the desired NodeJS version for the project. In my testing this is "10.16.0" but we should probably test with a bunch of reasonable versions.
